### PR TITLE
アルファ値で加重平均するように変更．

### DIFF
--- a/script/RotBlur_M.frag
+++ b/script/RotBlur_M.frag
@@ -5,7 +5,6 @@ in vec2 TexCoord;
 layout(location = 0) out vec4 FragColor;
 
 uniform sampler2D texture0;
-uniform float stepAngle;
 uniform int quality;
 uniform vec2 resolution;
 uniform vec2 pivot;
@@ -17,13 +16,21 @@ void main() {
     vec2 uv1 = (TexCoord * resolution - pivot) * rPos;
     vec2 uv2 = uv1;
     vec4 color = texture(texture0, clamp((uv1 + pivot) / resolution, 0, 1));
+    color.rgb *= color.a;
 
     for(int i = 1; i <= quality; i++){
         uv1 *= rot1;
-        color += texture(texture0, clamp((uv1 + pivot) / resolution, 0, 1));
+        vec4 c = texture(texture0, clamp((uv1 + pivot) / resolution, 0, 1));
+        c.rgb *= c.a;
+        color += c;
 
         uv2 *= rot2;
-        color += texture(texture0, clamp((uv2 + pivot) / resolution, 0, 1));
+        c = texture(texture0, clamp((uv2 + pivot) / resolution, 0, 1));
+        c.rgb *= c.a;
+        color += c;
     }
-    FragColor = color / (quality * 2 + 1);
+
+    color.rgb /= color.a;
+    color.a /= quality * 2 + 1;
+    FragColor = color;
 }


### PR DESCRIPTION
白の3角形に範囲1のぼかしをかけてから回転ブラーをかけると次のように暗くなってしまいます．(`quality=2` の例，青の背景を置いています．)

![blur_r11](https://github.com/user-attachments/assets/2f196ef4-4467-4824-a5d3-4cc7d7d05fe8)

参考までにぼかしをかけない場合は次のようになります．

![normal](https://github.com/user-attachments/assets/8cc95237-5376-4828-a881-2b5f7d58cc47)

拡張編集標準のぼかしをかけると完全透明ピクセルの色成分は黒になりますが，その黒色が計算に利用されてしまったのが原因です．色の平均計算の方法を，アルファ値での荷重平均にすることで自然になりました．（あるいは，[GDI+の `PixelFormat32bppPARGB`](https://learn.microsoft.com/en-us/windows/win32/gdiplus/-gdiplus-constant-image-pixel-format-constants) のピクセル形式で単純平均をとったという言い方もできます．）

![blur_pr](https://github.com/user-attachments/assets/d4d0c844-2351-4cb2-92e9-537639927a62)

あとついでに，未使用になっていた uniform 変数の `stepAngle` も削除しました．

以上ご確認お願いします．
