### PR TITLE
Division by zero prevention．

### DIFF
--- a/script/RotBlur_M.frag
+++ b/script/RotBlur_M.frag
@@ -30,7 +30,8 @@ void main() {
         color += c;
     }
 
-    color.rgb /= color.a;
-    color.a /= quality * 2 + 1;
-    FragColor = color;
+    float is_zero = step(color.a, 0.0);
+    color.rgb = mix(color.rgb / max(color.a, 0.0001), vec3(0.0), is_zero);
+    color.a /= (quality * 2 + 1);
+    FragColor = clamp(color, 0.0, 1.0);
 }

--- a/script/RotBlur_M.frag
+++ b/script/RotBlur_M.frag
@@ -32,6 +32,6 @@ void main() {
 
     float is_zero = step(color.a, 0.0);
     color.rgb = mix(color.rgb / max(color.a, 0.0001), vec3(0.0), is_zero);
-    color.a /= (quality * 2 + 1);
+    color.a /= quality * 2 + 1;
     FragColor = clamp(color, 0.0, 1.0);
 }


### PR DESCRIPTION
加重平均でアルファ値の総和で除算を行ったときに0除算が発生するリスクを回避しました．また，clamp関数で最終的な値を0から1の間に収めています．

確認していただければ幸いです．